### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "data operations"
   ],
   "description": "for both images and their annotations",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "task_location": "workspace_tasks",
   "isolate": true,
@@ -19,7 +19,9 @@
   "poster": "https://user-images.githubusercontent.com/106374579/183634421-0cb94591-5ea6-4de2-9fd2-fccb72b241d5.png",
   "context_menu": {
     "context_category": "Transform",
-    "target": ["images_project"]
+    "target": [
+      "images_project"
+    ]
   },
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000

--- a/config.json
+++ b/config.json
@@ -9,8 +9,8 @@
     "data operations"
   ],
   "description": "for both images and their annotations",
-  "docker_image": "supervisely/data-operations:6.73.469",
-  "instance_version": "6.15.2",
+  "docker_image": "supervisely/data-operations:6.73.564",
+  "instance_version": "6.15.60",
   "task_location": "workspace_tasks",
   "isolate": true,
   "icon": "https://i.imgur.com/ZSM70pg.png",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.469
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
